### PR TITLE
Elastic Recheck integration

### DIFF
--- a/reports/erhealth.py
+++ b/reports/erhealth.py
@@ -7,5 +7,5 @@ health_url = "http://health.sbarnea.com/"
 def get_health_link(bug_id):
     response = requests.get(base_url + str(bug_id) + ".yaml")
     if response.status_code == 200:
-        return health_url + str(bug_id)
+        return health_url + "#" + str(bug_id)
     return ""

--- a/reports/erhealth.py
+++ b/reports/erhealth.py
@@ -1,11 +1,11 @@
 import requests
 
-base_url = "https://opendev.org/openstack/tripleo-ci-health-queries/raw/branch/master/output/elastic-recheck"
+base_url = "https://opendev.org/openstack/tripleo-ci-health-queries/raw/branch/master/output/elastic-recheck/"
 health_url = "http://health.sbarnea.com/"
 
 
 def get_health_link(bug_id):
-    response = requests.get(base_url + str(bug_id) + "yaml")
+    response = requests.get(base_url + str(bug_id) + ".yaml")
     if response.status_code == 200:
         return health_url + str(bug_id)
     return ""

--- a/reports/erhealth.py
+++ b/reports/erhealth.py
@@ -1,0 +1,11 @@
+import requests
+
+base_url = "https://opendev.org/openstack/tripleo-ci-health-queries/raw/branch/master/output/elastic-recheck"
+health_url = "http://health.sbarnea.com/"
+
+
+def get_health_link(bug_id):
+    response = requests.get(base_url + str(bug_id) + "yaml")
+    if response.status_code == 200:
+        return health_url + str(bug_id)
+    return ""

--- a/statusreport.py
+++ b/statusreport.py
@@ -32,6 +32,7 @@ import configparser
 import os
 from launchpadlib.launchpad import Launchpad
 
+from reports.erhealth import get_health_link
 from reports.launchpad import LaunchpadReport
 import reports.trello as trello
 
@@ -117,6 +118,7 @@ class StatusReport(object):
             for bug in critical_bugs_with_out_escalation_cards:
                 bug_title = list_of_bugs[bug].title
                 bug_link = list_of_bugs[bug].web_link
+                health_link = get_health_link(bug.id)
 
                 card_title = "[CIX][LP:" + str(bug) + "][tripleoci][proa] " + \
                     str(bug_title)
@@ -126,7 +128,7 @@ class StatusReport(object):
                 trello_cards = trello.Cards(trello_api_context)
                 trello_cards.create(card_title,
                                     trello_list,
-                                    desc=bug_link)
+                                    desc=bug_link + "\n" + health_link)
 
 @ click.command()
 @ click.option("--config_file", default="config/critical-alert-escalation.cfg",

--- a/statusreport.py
+++ b/statusreport.py
@@ -118,7 +118,7 @@ class StatusReport(object):
             for bug in critical_bugs_with_out_escalation_cards:
                 bug_title = list_of_bugs[bug].title
                 bug_link = list_of_bugs[bug].web_link
-                health_link = get_health_link(bug.id)
+                health_link = get_health_link(list_of_bugs[bug].id)
 
                 card_title = "[CIX][LP:" + str(bug) + "][tripleoci][proa] " + \
                     str(bug_title)


### PR DESCRIPTION
When a card is created it checks the queries repo to see if a tripleo health query exists. If so it appends the link to the graph to the trello card description.