### PR TITLE
Update health url if not present in card desc

### DIFF
--- a/reports/erhealth.py
+++ b/reports/erhealth.py
@@ -1,4 +1,5 @@
 import requests
+import re
 
 base_url = "https://opendev.org/openstack/tripleo-ci-health-queries/raw/branch/master/output/elastic-recheck/"
 health_url = "http://health.sbarnea.com/"
@@ -7,5 +8,33 @@ health_url = "http://health.sbarnea.com/"
 def get_health_link(bug_id):
     response = requests.get(base_url + str(bug_id) + ".yaml")
     if response.status_code == 200:
-        return health_url + "#" + str(bug_id)
+        return "\n" + health_url + "#" + str(bug_id)
     return ""
+
+
+def get_bug_id_from_card(card):
+    """Finds LP bug id in card name"""
+    pattern = "^\\[CIX]\\[LP:((.*?))]"
+    match_found = re.search(pattern, card["name"])
+    if match_found:
+        bug_id = match_found.group(1)
+        return bug_id
+    return None
+
+
+def is_health_link_in_desc(card):
+    """Checks if card has health link in desc"""
+    pattern = health_url
+    return re.search(pattern, card["desc"])
+
+
+def add_health_link(card):
+    """Adds health link if present to card"""
+    # Updates health link in each card for now
+    bug_id = get_bug_id_from_card(card)
+    if bug_id:
+        health_link = get_health_link(bug_id)
+        if not is_health_link_in_desc(card):
+            desc = card["desc"] + health_link
+            return desc
+    return card["desc"]

--- a/reports/trello.py
+++ b/reports/trello.py
@@ -252,3 +252,12 @@ class Cards(object):
         response = requests.get(getCardsUrl, params=self._api.Payload)
         response.raise_for_status()
         return json.loads(response.text)
+
+    def update(self, card_id, desc):
+        "update card"
+        url = "%s/cards/%s" % (self._api.ApiRootUrl, card_id)
+        response = requests.put(url,
+                                params=self._api.Payload,
+                                data=dict(desc=desc))
+        response.raise_for_status()
+        return json.loads(response.text)


### PR DESCRIPTION
1928933
1929551
1929634
1932261
all cards 970
Updated card with tripleo-health[CIX][LP:1926649][tripleoci][proa] master: Gather podman infos fails w/ no log



Let's change the logging a bit.. ( perhaps to what I have here ) but this works :) Well done!
FYI: context is key..   print("Updated card with tripleo-health" + card["name"])